### PR TITLE
Fixes to Screen and Events

### DIFF
--- a/Sources/sdg/Object.hx
+++ b/Sources/sdg/Object.hx
@@ -6,6 +6,7 @@ import kha.FastFloat;
 import kha.math.Vector2;
 import sdg.components.Component;
 import sdg.math.Vector2b;
+import sdg.event.IEventDispatcher;
 
 @:allow(sdg.Screen)
 class Object
@@ -74,6 +75,10 @@ class Object
 	 * Components that updates and affect the object
 	 */
 	public var components:Array<Component>;
+	/**
+	 * Components that updates and affect the object
+	 */
+	public var eventDispatcher:IEventDispatcher;
 	/**
 	 * The graphic used by this object
 	 */

--- a/Sources/sdg/Screen.hx
+++ b/Sources/sdg/Screen.hx
@@ -298,8 +298,10 @@ class Screen
         if (destroyList.length > 0)
         {
             for (object in destroyList)
+			{
+				object.destroy();
                 object = null;
-                
+			}   
             Sdg.clear(destroyList);
         }
 

--- a/Sources/sdg/components/EventDispatcher.hx
+++ b/Sources/sdg/components/EventDispatcher.hx
@@ -15,6 +15,7 @@ class EventDispatcher extends Component implements IEventDispatcher
 	public override function init():Void 
 	{
 		super.init();
+		object.eventDispatcher = this;
 	}
 
 	/**
@@ -77,7 +78,7 @@ class EventDispatcher extends Component implements IEventDispatcher
 		{
 			eventObject = new EventObject();
 		}
-		if (listeners.exists(name) && !eventObject.bubble) 
+		if (listeners.exists(name) && !eventObject.bubble)
 		{
 			for (func in listeners[name])
 			{
@@ -87,6 +88,15 @@ class EventDispatcher extends Component implements IEventDispatcher
 		if(eventObject.bubble)
 		{
 			EventSystem.get().dispatch(name, eventObject);
+		}
+	}
+
+	public override function destroy():Void	
+	{
+		for(i in listeners.keys())
+		{
+			EventSystem.get().removeEvent(i, this);
+			listeners.remove(i);
 		}
 	}
 }

--- a/Sources/sdg/event/EventSystem.hx
+++ b/Sources/sdg/event/EventSystem.hx
@@ -39,7 +39,7 @@ class EventSystem
 
 	public function dispatch(name:String, eventObject:EventObject)
 	{
-		if(dispatchMap.exists(name))
+  		if(dispatchMap.exists(name))
 		{
 			for(i in dispatchMap.get(name))
 			{

--- a/Sources/sdg/event/IEventDispatcher.hx
+++ b/Sources/sdg/event/IEventDispatcher.hx
@@ -1,6 +1,11 @@
 package sdg.event;
+import haxe.Constraints.Function;
 
 interface IEventDispatcher
 {
 	public function dispatchEvent(name:String, eventObject:EventObject = null):Void;
+	
+	public function removeEvent(name:String, callback:Function):Void;
+
+	public function addEvent(name:String, callback:Function):Void;
 }


### PR DESCRIPTION
Found that the screen didn't destroy objects before nulling them, which meant any clean up code in the object wasn't getting run.

Added Event to Object to make it more central and usable. 

Ended up finding some holes in the events system, primarily the lack of clean up functionality and the interface for the dispatcher was too limited.